### PR TITLE
Add JSON schema validation workflow

### DIFF
--- a/.github/workflows/json-schema-validate.yml
+++ b/.github/workflows/json-schema-validate.yml
@@ -1,0 +1,23 @@
+name: Validate workflows JSON
+
+on:
+  push:
+    paths:
+      - 'workflows/**/*.json'
+      - '.github/schemas/workflow.schema.json'
+  pull_request:
+    paths:
+      - 'workflows/**/*.json'
+      - '.github/schemas/workflow.schema.json'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate workflow JSON files
+        uses: cardinalby/schema-validator-action@v1
+        with:
+          files: 'workflows/**/*.json'
+          schema: '.github/schemas/workflow.schema.json'
+


### PR DESCRIPTION
## Summary
- validate workflow JSON files via cardinalby/schema-validator-action on push and PR

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6863000b1618832e9575ddd03035f3af